### PR TITLE
feat: Implement basket badge and shared product list

### DIFF
--- a/app/src/main/java/com/example/e_commerce/MainActivity.kt
+++ b/app/src/main/java/com/example/e_commerce/MainActivity.kt
@@ -3,10 +3,11 @@ package com.example.e_commerce
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import com.google.android.material.snackbar.Snackbar
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
@@ -14,13 +15,19 @@ import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.example.e_commerce.databinding.ActivityMainBinding
+import com.google.android.material.badge.BadgeDrawable
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     private lateinit var appBar: AppBarConfiguration
     private lateinit var binding: ActivityMainBinding
+    private lateinit var badge: BadgeDrawable
+
+
+    private val sharedViewModel: SharedViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +46,7 @@ class MainActivity : AppCompatActivity() {
         appBar = AppBarConfiguration(navController.graph)
         setupActionBarWithNavController(navController , appBar)
 
+        badge = binding.bottomNavigation.getOrCreateBadge(R.id.fragment_basket)
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
             binding.bottomNavigation.updatePadding(bottom = insets.systemWindowInsetBottom)
@@ -46,6 +54,7 @@ class MainActivity : AppCompatActivity() {
             insets
         }
 
+        initFlows()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -63,5 +72,18 @@ class MainActivity : AppCompatActivity() {
         val navController = findNavController(R.id.nav_host_fragment_content_main)
         return navController.navigateUp(appBar)
                 || super.onSupportNavigateUp()
+    }
+
+    private fun initFlows() {
+        lifecycleScope.launch {
+            sharedViewModel.productList.collect { list ->
+                if (list.isEmpty()) {
+                    badge.isVisible = false
+                } else {
+                    badge.isVisible = true
+                    badge.number = list.size
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/e_commerce/SharedViewModel.kt
+++ b/app/src/main/java/com/example/e_commerce/SharedViewModel.kt
@@ -1,0 +1,22 @@
+package com.example.e_commerce
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.e_commerce.data.local.entity.ProductEntity
+import com.example.e_commerce.domain.usecase.GetAllProductUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class SharedViewModel @Inject constructor(
+    private val getAllProductUseCase: GetAllProductUseCase
+): ViewModel() {
+
+    val productList: StateFlow<List<ProductEntity>> =
+        getAllProductUseCase()
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+}

--- a/app/src/main/java/com/example/e_commerce/data/local/dao/ProductDao.kt
+++ b/app/src/main/java/com/example/e_commerce/data/local/dao/ProductDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Query
 import androidx.room.Update
 import com.example.e_commerce.data.local.entity.FavoriteEntity
 import com.example.e_commerce.data.local.entity.ProductEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ProductDao {
@@ -34,5 +35,8 @@ interface ProductDao {
 
     @Update
     suspend fun updateProduct(product: ProductEntity)
+
+     @Query("SELECT * FROM products")
+    fun getAllProductsWithFlow(): Flow<List<ProductEntity>>
 
 }

--- a/app/src/main/java/com/example/e_commerce/data/repository/local/LocalProductRepository.kt
+++ b/app/src/main/java/com/example/e_commerce/data/repository/local/LocalProductRepository.kt
@@ -2,6 +2,7 @@ package com.example.e_commerce.data.repository.local
 
 import com.example.e_commerce.data.local.entity.FavoriteEntity
 import com.example.e_commerce.data.local.entity.ProductEntity
+import kotlinx.coroutines.flow.Flow
 
 interface LocalProductRepository {
     suspend fun getFavoriteProducts(): List<FavoriteEntity>?
@@ -13,5 +14,6 @@ interface LocalProductRepository {
     suspend fun deleteProduct(item: ProductEntity)
     suspend fun getProduct(id: String): ProductEntity?
     suspend fun updateProduct(product: ProductEntity)
+    fun getAllProductsWithFlow(): Flow<List<ProductEntity>>
 
 }

--- a/app/src/main/java/com/example/e_commerce/domain/repository/local/LocalProductRepositoryImpl.kt
+++ b/app/src/main/java/com/example/e_commerce/domain/repository/local/LocalProductRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.example.e_commerce.data.local.entity.FavoriteEntity
 import com.example.e_commerce.data.local.entity.ProductEntity
 import com.example.e_commerce.data.repository.local.LocalProductRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -45,4 +46,6 @@ class LocalProductRepositoryImpl @Inject constructor(
     override suspend fun updateProduct(product: ProductEntity) = withContext(Dispatchers.IO) {
         return@withContext productDao.updateProduct(product)
     }
+
+    override fun getAllProductsWithFlow(): Flow<List<ProductEntity>> = productDao.getAllProductsWithFlow()
 }

--- a/app/src/main/java/com/example/e_commerce/domain/usecase/GetAllProductUseCase.kt
+++ b/app/src/main/java/com/example/e_commerce/domain/usecase/GetAllProductUseCase.kt
@@ -1,0 +1,15 @@
+package com.example.e_commerce.domain.usecase
+
+import com.example.e_commerce.data.local.entity.ProductEntity
+import com.example.e_commerce.data.repository.local.LocalProductRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAllProductUseCase @Inject constructor(
+    private val localProductRepository: LocalProductRepository
+) {
+
+    operator fun invoke(): Flow<List<ProductEntity>> {
+        return localProductRepository.getAllProductsWithFlow()
+    }
+}


### PR DESCRIPTION
This commit introduces a badge on the basket icon in the `BottomNavigationView` that displays the number of items in the basket. It also creates a `SharedViewModel` to provide a `StateFlow` of the product list, allowing different parts of the app to observe changes in the basket.

The following changes were made:
- In `ProductDao.kt`:
    - Added `getAllProductsWithFlow()` to return a `Flow<List<ProductEntity>>`.
- In `LocalProductRepository.kt` and `LocalProductRepositoryImpl.kt`:
    - Added `getAllProductsWithFlow()` to expose the new DAO method.
- Created `GetAllProductUseCase.kt`:
    - This use case retrieves the flow of products from `LocalProductRepository`.
- Created `SharedViewModel.kt`:
    - Injects `GetAllProductUseCase`.
    - Exposes `productList` as a `StateFlow<List<ProductEntity>>`, which emits the current list of products in the basket.
- In `MainActivity.kt`:
    - Injected `SharedViewModel`.
    - Created a `BadgeDrawable` for the basket item in `bottomNavigation`.
    - Added `initFlows()` function to observe `sharedViewModel.productList`.
        - Updates the badge visibility and number based on the `productList` size. If the list is empty, the badge is hidden; otherwise, it shows the count.