### PR TITLE
feat: Implement product search functionality

### DIFF
--- a/app/src/main/java/com/example/e_commerce/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/e_commerce/ui/home/HomeFragment.kt
@@ -68,6 +68,10 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         initFlows()
         initAdapter()
         viewModel.fetchProducts()
+
+        binding.searchBar.setOnSearchTextChanged {
+            viewModel.setSearchQuery(it)
+        }
     }
 
     private fun initAdapter() {
@@ -93,7 +97,15 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.products.collect { products ->
-                    products?.let {
+                    products?.let { adapter.submitList(it) }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.filteredProductList.collect { filtered ->
+                    filtered?.let {
                         adapter.submitList(it)
                     }
                 }


### PR DESCRIPTION
This commit introduces search functionality to the home screen, allowing users to filter the product list based on a search query.

The following changes were made:
- In `HomeFragment.kt`:
    - Added an `setOnSearchTextChanged` listener to `binding.searchBar`. This listener calls `viewModel.setSearchQuery(it)` whenever the search text changes.
    - Updated `initFlows()` to collect from a new `filteredProductList` StateFlow in the ViewModel, in addition to the existing `products` flow. The adapter's list is now updated based on the emissions from `filteredProductList`.
- In `HomeFragmentViewModel.kt`:
    - Added a `_searchQuery` `MutableStateFlow` to hold the current search string.
    - Introduced `filteredProductList` as a `StateFlow`. This flow is created by combining the `_products` flow and the `_searchQuery` flow.
        - When either the product list or the search query changes, this combined flow re-evaluates.
        - If the search query is empty, it emits the full product list. - If the search query is not empty, it filters the product list, keeping only products whose names contain the query (case-insensitive). - The `stateIn` operator is used with `SharingStarted.Lazily` to make this a hot flow that starts when first collected and shares its value among collectors.
    - Added `setSearchQuery(query: String)` function to update the `_searchQuery` StateFlow with the new search term.